### PR TITLE
Dimmable Switches Were Getting Classified as Light Bulbs

### DIFF
--- a/accessories/smartthings.js
+++ b/accessories/smartthings.js
@@ -87,7 +87,7 @@ function SmartThingsAccessory(platform, device) {
             	    	that.platform.api.runCommand(callback, that.deviceid, "setLevel", {value1: value }); });
 			that.platform.addAttributeUsage("level", this.deviceid, thisCharacteristic);
         
-        } else {
+        } else if (device.capabilities["Light"] !== undefined) {
             this.deviceGroup = "lights";
             thisCharacteristic = this.getaddService(Service.Lightbulb).getCharacteristic(Characteristic.On)
             thisCharacteristic.on('get', function(callback) { callback(null, that.device.attributes.switch == "on"); });
@@ -232,6 +232,13 @@ function SmartThingsAccessory(platform, device) {
                     that.platform.api.runCommand(callback, that.deviceid, "off");
             });
 		that.platform.addAttributeUsage("switch", this.deviceid, thisCharacteristic);
+	    
+        if (device.capabilities["Switch Level"] !== undefined) {
+            thisCharacteristic = this.getaddService(Service.Lightbulb).getCharacteristic(Characteristic.Brightness)
+            thisCharacteristic.on('get', function(callback) { callback(null, parseInt(that.device.attributes.level)); });
+            thisCharacteristic.on('set', function(value, callback) { that.platform.api.runCommand(callback, that.deviceid, "setLevel", { value1: value }); });
+			that.platform.addAttributeUsage("level", this.deviceid, thisCharacteristic);
+	}
     }
 
     if ((device.capabilities["Smoke Detector"] !== undefined) && (that.device.attributes.smoke)) {

--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ SmartThingsPlatform.prototype = {
 		var foundAccessories = [];
 		this.deviceLookup = [];
 		this.unknownCapabilities = [];
-		this.knownCapabilities = ["Switch", "Color Control", "Battery", "Polling", "Lock", "Refresh", "Lock Codes", "Sensor", "Actuator",
+		this.knownCapabilities = ["Switch", "Light", "Color Control", "Battery", "Polling", "Lock", "Refresh", "Lock Codes", "Sensor", "Actuator",
 			"Configuration", "Switch Level", "Temperature Measurement", "Motion Sensor", "Color Temperature",
 			"Contact Sensor", "Three Axis", "Acceleration Sensor", "Momentary", "Door Control", "Garage Door Control",
 			"Relative Humidity Measurement", "Presence Sensor", "Thermostat", "Energy Meter", "Power Meter",


### PR DESCRIPTION
I installed a dimmable switch today that contained both `Switch` and `Switch Level` and this caused some issues with integrating with HomeKit and homebridge.  When installed in homebridge two devices were present, one normal switch and one dimmable light bulb.  On investigating the code, it looks all `Switch Level` capabilities were assumed to be a `Switch` if it didn't get excluded as a `fan` or `shades`.

Here is a dump of my `deviceList` for information in what I am trying to accomplish.

```json
"deviceList": [
    {
      "name": "Garage Lights",
      "basename": "GE Zigbee In-Wall Dimmer",
      "deviceid": "c36222ac-XXXXXXX-4ed3cbf3b048",
      "status": "ONLINE",
      "manufacturerName": "Jasco Products",
      "modelName": "45857",
      "lastTime": "2017-06-04T06:16:32+0000",
      "capabilities": {
        "Switch": 1,
        "Configuration": 1,
        "Switch Level": 1,
        "Refresh": 1,
        "Power Meter": 1,
        "Sensor": 1,
        "Actuator": 1,
        "Health Check": 1,
        "Light": 1
      },
      "commands": {
        "on": [],
        "off": [],
        "configure": [],
        "setLevel": [
          "NUMBER",
          "NUMBER"
        ],
        "refresh": [],
        "ping": []
      },
      "attributes": {
        "switch": "off",
        "level": 52,
        "power": 0,
        "checkInterval": 720
      }
    }
  ]
```

Let me know if you see any problems with my code.