### PR TITLE
Add ability to exclude devices or certain device capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ If you installed the previous update that doesn't allow selecting devices, you n
 
 ### Config.json Settings
 
-Example of all settings. Not all ssettings are required. Read the breakdown below.
+Example of all settings. Not all settings are required. Read the breakdown below.
 ```
 	{
 	   "platform": "homebridge-smartthings.SmartThings",
@@ -107,7 +107,15 @@ Example of all settings. Not all ssettings are required. Read the breakdown belo
         "update_method": "direct",
         "direct_ip": "192.168.0.45",
         "direct_port": 8000,
-        "api_seconds": 30
+        "api_seconds": 30,
+        "excluded_capabilities": {
+            "SMARTTHINGS-DEVICE-ID-1" : [
+                "Switch",
+                "Temperature Measurement"
+            ],
+            "SMARTTHINGS-DEVICE-ID-2" : [
+                "*"
+            ]
 	}
 ```
 * "platform" and "name"
@@ -145,6 +153,12 @@ Example of all settings. Not all ssettings are required. Read the breakdown belo
  * This setting only applies if update_method is api.
  * This is how often the api will poll for updates. This update method is not recommended.
 
+* "excluded_capabilities"
+**_Optional_** Defaults to None
+ * Specify the SmartThings device by ID and the associated capabilities you want homebridge-smartthings to ignore
+ * This prevents a SmartThings device creating unwanted or redundant HomeKit accessories
+ * Use a wildcard ("*") to ignore the device completely
+
 ##Reporting Devices for Development
 
 * The first step is to install the smartapp to the device
@@ -161,6 +175,9 @@ Example of all settings. Not all ssettings are required. Read the breakdown belo
 * If you receive an "error at req", this is normally caused by network issues and the plugin should always auto-recover. Please verify you have internet access on the device before posting about these. If you get one or two ENOTFOUND errors in the middle of the night, it is probably your modem resetting and is nothing to worry about. 
  
 ## What's New
+
+* 0.5.3
+ * [Plugin] Add option to exclude devices or certain device capabilities
 
 * 0.5.2
  * [SmartApp] Various fixes to fix flaws in the implementation of the direct feed and optional pubnub feed.

--- a/accessories/smartthings.js
+++ b/accessories/smartthings.js
@@ -52,8 +52,14 @@ function SmartThingsAccessory(platform, device) {
 
     this.deviceGroup = "unknown"; //This way we can easily tell if we set a device group
 	var thisCharacteristic;
-	
-    if (device.capabilities["Switch Level"] !== undefined) {
+    var capability;
+    
+    if (device.excludedCapabilities.indexOf("*") >= 0){
+        return null
+    }
+
+    capability = "Switch Level";
+    if (device.capabilities[capability] !== undefined && device.excludedCapabilities.indexOf(capability) < 0) {
         if (device.commands.levelOpenClose) {
             //This is a Window Shade
             this.deviceGroup = "shades"
@@ -117,7 +123,8 @@ function SmartThingsAccessory(platform, device) {
         }
     }
 
-    if (device.capabilities["Garage Door Control"] !== undefined) {
+    capability = "Garage Door Control";
+    if (device.capabilities[capability] !== undefined && device.excludedCapabilities.indexOf(capability) < 0) {
         this.deviceGroup = "garage_doors";
 		
         thisCharacteristic = this.getaddService(Service.GarageDoorOpener).getCharacteristic(Characteristic.TargetDoorState)
@@ -161,7 +168,8 @@ function SmartThingsAccessory(platform, device) {
         this.getaddService(Service.GarageDoorOpener).setCharacteristic(Characteristic.ObstructionDetected, false);
     }
 
-    if (device.capabilities["Lock"] !== undefined) {
+    capability = "Lock";
+    if (device.capabilities[capability] !== undefined && device.excludedCapabilities.indexOf(capability) < 0) {
         this.deviceGroup = "locks";
 		
         thisCharacteristic = this.getaddService(Service.LockMechanism).getCharacteristic(Characteristic.LockCurrentState)
@@ -217,11 +225,14 @@ function SmartThingsAccessory(platform, device) {
 // Thinking of implementing this as a Door service.
 //    }
 
-    if (device.capabilities["Button"] !== undefined) {
+    capability = "Button";
+    if (device.capabilities[capability] !== undefined && device.excludedCapabilities.indexOf(capability) < 0) {
         this.deviceGroup = " button";
         
     }
-    if (device.capabilities["Switch"] !== undefined && this.deviceGroup == "unknown") {
+
+    capability = "Switch";
+    if (device.capabilities[capability] !== undefined && device.excludedCapabilities.indexOf(capability) < 0 && this.deviceGroup == "unknown") {
         this.deviceGroup = "switch";
         thisCharacteristic = this.getaddService(Service.Switch).getCharacteristic(Characteristic.On)
         thisCharacteristic.on('get', function(callback) { callback(null, that.device.attributes.switch == "on"); })
@@ -241,7 +252,8 @@ function SmartThingsAccessory(platform, device) {
 	}
     }
 
-    if ((device.capabilities["Smoke Detector"] !== undefined) && (that.device.attributes.smoke)) {
+    capability = "Smoke Detector";
+    if (device.capabilities[capability] !== undefined && device.excludedCapabilities.indexOf(capability) < 0 && that.device.attributes.smoke) {
         this.deviceGroup = "detectors";
 
         thisCharacteristic = this.getaddService(Service.SmokeSensor).getCharacteristic(Characteristic.SmokeDetected)
@@ -254,7 +266,8 @@ function SmartThingsAccessory(platform, device) {
  		that.platform.addAttributeUsage("smoke", this.deviceid, thisCharacteristic);
    }
 
-    if ((device.capabilities["Carbon Monoxide Detector"] !== undefined) && (that.device.attributes.carbonMonoxide)) {
+   capability = "Carbon Monoxide Detector";
+    if (device.capabilities[capability] !== undefined && device.excludedCapabilities.indexOf(capability) < 0 && that.device.attributes.carbonMonoxide) {
         this.deviceGroup = "detectors";
         
 		thisCharacteristic = this.getaddService(Service.CarbonMonoxideSensor).getCharacteristic(Characteristic.CarbonMonoxideDetected)
@@ -267,7 +280,8 @@ function SmartThingsAccessory(platform, device) {
  		that.platform.addAttributeUsage("carbonMonoxide", this.deviceid, thisCharacteristic);
     }
 
-    if (device.capabilities["Motion Sensor"] !== undefined) {
+    capability = "Motion Sensor";
+    if (device.capabilities[capability] !== undefined && device.excludedCapabilities.indexOf(capability) < 0) {
         if (this.deviceGroup == 'unknown') this.deviceGroup = "sensor";
         
 		thisCharacteristic = this.getaddService(Service.MotionSensor).getCharacteristic(Characteristic.MotionDetected)
@@ -275,7 +289,8 @@ function SmartThingsAccessory(platform, device) {
  		that.platform.addAttributeUsage("motion", this.deviceid, thisCharacteristic);
     }
 
-    if (device.capabilities["Water Sensor"] !== undefined) {
+    capability = "Water Sensor";
+    if (device.capabilities[capability] !== undefined && device.excludedCapabilities.indexOf(capability) < 0) {
         if (this.deviceGroup == 'unknown') this.deviceGroup = "sensor";
 		
         thisCharacteristic = this.getaddService(Service.LeakSensor).getCharacteristic(Characteristic.LeakDetected)
@@ -286,7 +301,8 @@ function SmartThingsAccessory(platform, device) {
  		that.platform.addAttributeUsage("water", this.deviceid, thisCharacteristic);
     }
 
-    if (device.capabilities["Presence Sensor"] !== undefined) {
+    capability = "Presence Sensor";
+    if (device.capabilities[capability] !== undefined && device.excludedCapabilities.indexOf(capability) < 0) {
         if (this.deviceGroup == 'unknown') this.deviceGroup = "sensor";
 		
         thisCharacteristic = this.getaddService(Service.OccupancySensor).getCharacteristic(Characteristic.OccupancyDetected)
@@ -294,14 +310,16 @@ function SmartThingsAccessory(platform, device) {
  		that.platform.addAttributeUsage("presence", this.deviceid, thisCharacteristic);
     }
 
-    if (device.capabilities["Relative Humidity Measurement"] !== undefined) {
+    capability = "Relative Humidity Measurement";
+    if (device.capabilities[capability] !== undefined && device.excludedCapabilities.indexOf(capability) < 0) {
         if (this.deviceGroup == 'unknown') this.deviceGroup = "sensor";
         thisCharacteristic = this.getaddService(Service.HumiditySensor).getCharacteristic(Characteristic.CurrentRelativeHumidity)
         thisCharacteristic.on('get', function(callback) { callback(null, Math.round(that.device.attributes.humidity)); });
 		that.platform.addAttributeUsage("humidity", this.deviceid, thisCharacteristic);
     }
 
-    if (device.capabilities["Temperature Measurement"] !== undefined) {
+    capability = "Temperature Measurement";
+    if (device.capabilities[capability] !== undefined && device.excludedCapabilities.indexOf(capability) < 0) {
         if (this.deviceGroup == 'unknown') this.deviceGroup = "sensor";
         thisCharacteristic = this.getaddService(Service.TemperatureSensor).getCharacteristic(Characteristic.CurrentTemperature)
         thisCharacteristic.on('get', function(callback) {
@@ -313,7 +331,8 @@ function SmartThingsAccessory(platform, device) {
 		that.platform.addAttributeUsage("temperature", this.deviceid, thisCharacteristic);
     }
 
-    if (device.capabilities["Contact Sensor"] !== undefined) {
+    capability = "Contact Sensor";
+    if (device.capabilities[capability] !== undefined && device.excludedCapabilities.indexOf(capability) < 0) {
         if (this.deviceGroup == 'unknown') this.deviceGroup = "sensor";
         thisCharacteristic = this.getaddService(Service.ContactSensor).getCharacteristic(Characteristic.ContactSensorState)
         thisCharacteristic.on('get', function(callback) {
@@ -326,7 +345,8 @@ function SmartThingsAccessory(platform, device) {
  		that.platform.addAttributeUsage("contact", this.deviceid, thisCharacteristic);
    }
 
-    if (device.capabilities["Battery"] !== undefined) {
+    capability = "Battery";
+    if (device.capabilities[capability] !== undefined && device.excludedCapabilities.indexOf(capability) < 0) {
         thisCharacteristic = this.getaddService(Service.BatteryService).getCharacteristic(Characteristic.BatteryLevel)
         thisCharacteristic.on('get', function(callback) { callback(null, Math.round(that.device.attributes.battery)); });
 		that.platform.addAttributeUsage("battery", this.deviceid, thisCharacteristic);
@@ -343,28 +363,33 @@ function SmartThingsAccessory(platform, device) {
 		that.platform.addAttributeUsage("battery", this.deviceid, thisCharacteristic);
     }
 
-    if (device.capabilities["Energy Meter"] !== undefined) {
+    capability = "Energy Meter";
+    if (device.capabilities[capability] !== undefined && device.excludedCapabilities.indexOf(capability) < 0) {
         this.deviceGroup = 'EnergyMeter';
         thisCharacteristic = this.getaddService(Service.Outlet).addCharacteristic(EnergyCharacteristics.TotalConsumption1)
         thisCharacteristic.on('get', function(callback) { callback(null, Math.round(that.device.attributes.energy)); });
 		that.platform.addAttributeUsage("energy", this.deviceid, thisCharacteristic);
 	}
 
-    if (device.capabilities["Power Meter"] !== undefined) {	
+    capability = "Power Meter";
+    if (device.capabilities[capability] !== undefined && device.excludedCapabilities.indexOf(capability) < 0) {	
         thisCharacteristic = this.getaddService(Service.Outlet).addCharacteristic(EnergyCharacteristics.CurrentConsumption1)
         thisCharacteristic.on('get', function(callback) { callback(null, Math.round(that.device.attributes.power)); });
 		that.platform.addAttributeUsage("power", this.deviceid, thisCharacteristic);
     }
 
-    if (device.capabilities["Acceleration Sensor"] !== undefined) {
+    capability = "Acceleration Sensor";
+    if (device.capabilities[capability] !== undefined && device.excludedCapabilities.indexOf(capability) < 0) {
         if (this.deviceGroup == 'unknown') this.deviceGroup = "sensor";
     }
 
-    if (device.capabilities["Three Axis"] !== undefined) {
+    capability = "Three Axis";
+    if (device.capabilities[capability] !== undefined && device.excludedCapabilities.indexOf(capability) < 0) {
         if (this.deviceGroup == 'unknown') this.deviceGroup = "sensor";
     }
 
-	if (device.capabilities["Thermostat"] !== undefined) {
+    capability = "Thermostat";
+	if (device.capabilities[capability] !== undefined && device.excludedCapabilities.indexOf(capability) < 0) {
         this.deviceGroup = "thermostats";
         
 		thisCharacteristic = this.getaddService(Service.Thermostat).getCharacteristic(Characteristic.CurrentHeatingCoolingState)

--- a/index.js
+++ b/index.js
@@ -19,10 +19,11 @@ module.exports = function (homebridge) {
 };
 
 function SmartThingsPlatform(log, config) {
-	// Load Wink Authentication From Config File
+	// Load SmartThings Authentication From Config File
 	this.app_url = config["app_url"];
 	this.app_id = config["app_id"];
 	this.access_token = config["access_token"];
+	this.excludedCapabilities = config["excluded_capabilities"];
 
 	//This is how often it does a full refresh
 	this.polling_seconds = config["polling_seconds"];
@@ -63,6 +64,8 @@ SmartThingsPlatform.prototype = {
 					for (var i = 0; i < devices.length; i++) {
 						var device = devices[i];
 
+						device.excludedCapabilities = that.excludedCapabilities[device.deviceid] || ["None"]
+
 						var accessory = undefined;
 						if (that.deviceLookup[device.deviceid]) {
 							accessory = that.deviceLookup[device.deviceid];
@@ -74,7 +77,7 @@ SmartThingsPlatform.prototype = {
 								if ((accessory.services.length <= 1) || (accessory.deviceGroup == "unknown")) {
 									if (that.firstpoll) that.log("Device Skipped - Group " + accessory.deviceGroup + ", Name " + accessory.name + ", ID " + accessory.deviceid + ", JSON: " + JSON.stringify(device));
 								} else {
-									that.log("Device Added - Group " + accessory.deviceGroup + ", Name " + accessory.name + ", ID " + accessory.deviceid)//+", JSON: "+ JSON.stringify(device));
+									that.log("Device Added - Group " + accessory.deviceGroup + ", Name " + accessory.name + ", ID " + accessory.deviceid + ", Excluded: " + accessory.device.excludedCapabilities)//+", JSON: "+ JSON.stringify(device));
 									that.deviceLookup[accessory.deviceid] = accessory;
 									foundAccessories.push(accessory);
 								}


### PR DESCRIPTION
Hi,

It is common within SmartThings for devices to have several capabilities, some of which can become redundant when importing in to HomeKit.

As an example, a Thermostat could have seperate "Temperature Measurement" and "Switch" capabilities within SmartThings. When using homebridge-smartthings, the 1 Thermostat becomes 3 accessories, even though the native Thermostat Accessory already handles everything. 

This pull request allows users to exclude certain capabilities from certain devices, to prevent cluttering Homebridge with redundant or undesired accessories.

You can also imagine users wanting to completely exclude devices from Homebridge, this pull request allows devices to be completely excluded by specifying the wildcard ("*") parameter.

Let me know what you think! 😄 