### PR TITLE
Detect WindowShade via “presetPosition” command

### DIFF
--- a/accessories/smartthings.js
+++ b/accessories/smartthings.js
@@ -54,7 +54,7 @@ function SmartThingsAccessory(platform, device) {
 	var thisCharacteristic;
 	
     if (device.capabilities["Switch Level"] !== undefined) {
-        if (device.commands.levelOpenClose) {
+        if (device.commands.levelOpenClose || device.commands.presetPosition) {
             //This is a Window Shade
             this.deviceGroup = "shades"
 


### PR DESCRIPTION
As in title, SmartThings supports a "Window Shade" device type now, which means support for the custom "levelOpenClose" is no longer required.

For backwards compatibility reasons I believe it should be left in, but I am proposing to also check if the device supports the "presetPosition" command, which is unique to the Window Shade device type.