### PR TITLE
Add option to exclude certain SmartThings device capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ If you installed the previous update that doesn't allow selecting devices, you n
 
 ### Config.json Settings
 
-Example of all settings. Not all ssettings are required. Read the breakdown below.
+Example of all settings. Not all settings are required. Read the breakdown below.
 ```
 	{
 	   "platform": "homebridge-smartthings.SmartThings",
@@ -107,7 +107,12 @@ Example of all settings. Not all ssettings are required. Read the breakdown belo
         "update_method": "direct",
         "direct_ip": "192.168.0.45",
         "direct_port": 8000,
-        "api_seconds": 30
+        "api_seconds": 30,
+        "excluded_capabilities": {
+            "SMARTTHINGS-DEVICE-ID-1" : [
+                "Switch",
+                "Temperature Measurement"
+            ]
 	}
 ```
 * "platform" and "name"
@@ -144,6 +149,11 @@ Example of all settings. Not all ssettings are required. Read the breakdown belo
 **_Optional_** Defaults to 30
  * This setting only applies if update_method is api.
  * This is how often the api will poll for updates. This update method is not recommended.
+
+* "excluded_capabilities"
+**_Optional_** Defaults to None
+ * Specify the SmartThings device by ID and the associated capabilities you want homebridge-smartthings to ignore
+ * This prevents a SmartThings device creating unwanted or redundant HomeKit accessories
 
 ##Reporting Devices for Development
 

--- a/accessories/smartthings.js
+++ b/accessories/smartthings.js
@@ -38,6 +38,14 @@ function SmartThingsAccessory(platform, device) {
     Accessory.call(this, this.name, id);
     var that = this;
 
+	//Removing excluded capabilities from config
+	for (var i = 0; i < device.excludedCapabilities.length; i++) {
+		excludedCapability = device.excludedCapabilities[i];
+		if (device.capabilities[excludedCapability] !== undefined) {
+			platform.log.debug("Removing capability: "+excludedCapability+" for device: "+device.name)
+			delete device.capabilities[excludedCapability];
+		}
+	}
     //Get the Capabilities List
     for (var index in device.capabilities) {
         if ((platform.knownCapabilities.indexOf(index) == -1) && (platform.unknownCapabilities.indexOf(index) == -1))

--- a/index.js
+++ b/index.js
@@ -63,6 +63,7 @@ SmartThingsPlatform.prototype = {
 				var populateDevices = function (devices) {
 					for (var i = 0; i < devices.length; i++) {
 						var device = devices[i];
+						device.excludedCapabilities = that.excludedCapabilities[device.deviceid] || ["None"]
 
 						var accessory = undefined;
 						if (that.deviceLookup[device.deviceid]) {

--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ function SmartThingsPlatform(log, config) {
 	this.app_url = config["app_url"];
 	this.app_id = config["app_id"];
 	this.access_token = config["access_token"];
+    this.excludedCapabilities = config["excluded_capabilities"];
 
 	//This is how often it does a full refresh
 	this.polling_seconds = config["polling_seconds"];


### PR DESCRIPTION
It is common within SmartThings for devices to have several capabilities, some of which can become redundant when importing in to HomeKit.

As an example, a Thermostat could have seperate "Temperature Measurement" and "Switch" capabilities within SmartThings. When using homebridge-smartthings, the 1 Thermostat becomes 3 accessories, even though the native Thermostat Accessory already handles everything.

This pull request allows users to exclude certain capabilities from certain devices, to prevent cluttering Homebridge with redundant or undesired accessories.

Apologies for creating a new PR, hopefully this one is a little more maintainable 👍 